### PR TITLE
prevent firefox_distribution to be parsed as string

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,7 +15,6 @@ firefox_distribution_append: true
 firefox_default_lang: en-GB, en
 firefox_default_region: GB
 firefox_default_locale: en-GB
-firefox_distribution: "{{ firefox_bookmarks | default({}) }}"
 
 firefox_trusted_certs_file: /etc/ssl/certs/ca-certificates.crt
 

--- a/templates/distribution.ini.j2
+++ b/templates/distribution.ini.j2
@@ -1,7 +1,7 @@
 {# this template converts json/python dicts into ini format #}
 {# assumes a dict where top level keys are the ini sections and values are key,value pairs #}
 {% if firefox_distribution is defined %}
-    {% for section, entries in firefox_distribution.items() %} 
+    {% for section, entries in (firefox_bookmarks | default({})).items() %}
 [{{section}}]
             {% for key,value  in entries.items() %}
 {{key}}={{value}}


### PR DESCRIPTION
Prevents `firefox_distribution` to be parsed as a string by iterating over `firefox_bookmarks` directly within the template.